### PR TITLE
Switch upstream dep to ffi-libarchive

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ To use, require this gem before ffi-libarchive:
 
 ```
 require "ffi_libarchive_preload"
-require "ffi_libarchive"
+require "ffi-libarchive"
 Archive::Reader.open_filename("some.tar.gz").each_entry {|e| puts e.pathname}
 ```
 

--- a/ffi_libarchive_preload.gemspec
+++ b/ffi_libarchive_preload.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files = ["README.md", "ffi_libarchive_preload.gemspec", "Gemfile"] +
-    Dir["lib/*.rb"] + 
+    Dir["lib/*.rb"] +
     Dir["lib/ffi_libarchive_preload/*.rb"] +
     ["ext/Rakefile"] +
     ["ext/libarchive-#{FfiLibarchivePreload::VERSION}.tar.gz"]
@@ -27,5 +27,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler", "~> 1.17"
   spec.add_development_dependency "minitest", "~> 5.0"
-  spec.add_development_dependency "ffi_libarchive", "~> 1.1"
+  spec.add_development_dependency "ffi-libarchive", "~> 1.0"
 end

--- a/test/ffi_libarchive_dep_test.rb
+++ b/test/ffi_libarchive_dep_test.rb
@@ -1,11 +1,11 @@
 require "minitest/autorun"
 require "ffi_libarchive_preload"
-require "ffi_libarchive"
+require "ffi-libarchive"
 
 class FfiLibarchivePreloadTest < Minitest::Test
   def test_read_archive
     reader = Archive::Reader.open_filename("#{__dir__}/fixture.tar.gz")
-   
+
     filename = nil
     reader.each_entry do |entry|
       filename = entry.pathname


### PR DESCRIPTION
@buckelij I noticed that this gem is pointing at https://github.com/nthachus/ffi_libarchive as it's dev dependency. This was originally a fork of https://github.com/chef/ffi-libarchive but seems to be going in a different direction.

It doesn't matter so far since `Archive::Reader.open_filename` still works the same in both gems, but I thought it might be a good idea to point to the official upstream gem. It is easy to mix them up since the name only differs by `_` vs. `-`.